### PR TITLE
Add ODK 2 source code links

### DIFF
--- a/_pages/software/index.md
+++ b/_pages/software/index.md
@@ -49,6 +49,12 @@ Read more about [the ODK 2 Suite](/software/odk2/):
 - [**ODK Cloud Endpoints:**](https://docs.opendatakit.org/odk2/cloud-endpoints-intro/) A cloud server to host data and application files, and to support bi-directional data synchronization across disconnected mobile devices.
 - [**ODK Suitcase:**](https://docs.opendatakit.org/odk2/suitcase-intro/) A desktop tool for synchronizing data with a cloud endpoint.
 
+**Source code for all ODK 2 Suite products is available on GitHub:**
+
+- Mobile Tools and Libraries: [Survey](https://github.com/opendatakit/survey), [Tables](https://github.com/opendatakit/tables), [Services](https://github.com/opendatakit/services), [androidlibrary](https://github.com/opendatakit/androidlibrary), [androidcommon](https://github.com/opendatakit/androidcommon)
+- Desktop Tools and Libraries: [Application Designer](https://github.com/opendatakit/app-designer), [Suitcase](https://github.com/opendatakit/suitcase), [Sync Client](https://github.com/opendatakit/sync-client)
+- Server Tools and Configuration: [Sync Endpoint](https://github.com/opendatakit/sync-endpoint), [Sync Endpoint Containers](https://github.com/opendatakit/sync-endpoint-containers), [Sync Endpoint Web UI](https://github.com/opendatakit/sync-endpoint-web-ui), [Sync Endpoint Default Setup](https://github.com/opendatakit/sync-endpoint-default-setup)
+
 ## Other Helpful Links
 
 * [The ODK Forum:](https://forum.opendatakit.org) Home of the ODK community. Please search first.


### PR DESCRIPTION
Closes #68 

#### What is included in this PR?

This PR adds a list of links to the ODK 2 source code.

#### What is left to be done in the addressed issue?

This does not match exactly to the format that ODK 1 uses in the previous section. ODK 1 has a single link to https://github.com/opendatakit/opendatakit, which then provides links to Collect, Aggregate, and Build. There is not a similarly convenient link for ODK 2. However, if this list seems cumbersome or inappropriate in this area, we could create a wiki page or something that would serve as a single landing page for ODK 2 source, and link that from here instead. 