### PR TITLE
Move source links from Software to Downloads page

### DIFF
--- a/_pages/download/odk1.md
+++ b/_pages/download/odk1.md
@@ -28,15 +28,21 @@ Need to download a specific release? Use GitHub:
 
 * Download [Collect releases on GitHub](https://github.com/opendatakit/collect/releases)
 
+[Source Code](https://github.com/opendatakit/collect)
+
 ## ODK XLSForm
 
 XLSForm is available as an online and offline tool. The online version works with modern web browsers and the offline version works on Windows, macOS, and Linux.
 
 * Use [https://xlsform.opendatakit.org](xlsform.opendatakit.org) (Recommended)
 
+[Source Code for XLSForm Online](https://github.com/opendatakit/xlsform-online), [Source Code for the XLSForm server](https://github.com/opendatakit/xlsform-server)
+
 Download offline releases on GitHub:
 
 * Download [XLSForm releases on GitHub](https://github.com/opendatakit/xlsform-offline/releases)
+
+[Source Code for XLSForm Offline](https://github.com/opendatakit/xlsform-offline)
 
 ## ODK Build
 
@@ -48,11 +54,15 @@ Download offline releases on GitHub:
 
 * Download [Build releases on GitHub](https://github.com/opendatakit/build/releases)
 
+[Source Code](https://github.com/opendatakit/build)
+
 ## ODK Aggregate
 
 Aggregate is available for Windows, macOS, and Linux. There is also a Virtual Machine (VM) that runs on all platforms. 
 
 * Download [Aggregate releases on GitHub](https://github.com/opendatakit/aggregate/releases)
+
+[Source Code](https://github.com/opendatakit/aggregate)
 
 ## ODK Briefcase
 
@@ -60,11 +70,15 @@ Briefcase is available for Windows, macOS, and Linux.
 
 * Download [Briefcase releases on GitHub](https://github.com/opendatakit/briefcase/releases)
 
+[Source Code](https://github.com/opendatakit/briefcase)
+
 ## ODK Validate
 
 Validate is available for Windows, macOS, and Linux.
 
 * Download [Validate releases on GitHub](https://github.com/opendatakit/validate/releases)
+
+[Source Code](https://github.com/opendatakit/validate)
 
 ## ODK JavaRosa
 
@@ -74,4 +88,6 @@ JavaRosa is a Java library for software developers. Use Maven or Gradle through 
 
 Need to download a specific release? Use GitHub:
 
-* Download [JavaRosa releases on GitHub](https://github.com/opendatakit/collect/releases)
+* Download [JavaRosa releases on GitHub](https://github.com/opendatakit/javarosa/releases)
+
+[Source Code](https://github.com/opendatakit/javarosa)

--- a/_pages/download/odk2.md
+++ b/_pages/download/odk2.md
@@ -21,25 +21,35 @@ A mobile data curation Android app that enables users to see previously collecte
 
 Download [Tables releases on GitHub](https://github.com/opendatakit/tables/releases)
 
+[Source Code](https://github.com/opendatakit/tables)
+
 ## ODK Survey
 A question based data collection Android app that uses a predefined survey specified using the XLSXConverter (part of Application Designer). Survey requires ODK Services.
 
 Download [Survey releases on GitHub](https://github.com/opendatakit/survey/releases)
+
+[Source Code](https://github.com/opendatakit/survey)
 
 ## ODK Services
 An Android app that handles database access, file access, and data synchronization services with an ODK 2 Cloud Endpoint. 
 
 Download [Services releases on GitHub](https://github.com/opendatakit/services/releases)
 
+[Source Code](https://github.com/opendatakit/services)
+
 ## ODK Application Designer
 A  Windows/macOS/Linux design environment that runs in Chrome for creating, customizing, and previewing your forms that will render on Survey. 
 
 Download [Application Designer releases on GitHub](https://github.com/opendatakit/app-designer/releases)
 
+[Source Code](https://github.com/opendatakit/app-designer)
+
 ## ODK Suitcase
 A Windows/macOS/Linux tool for synchronizing data from an ODK 2 Cloud Endpoint into an exported CSV file.
 
 Download [Suitcase releases on GitHub](https://github.com/opendatakit/suitcase/releases)
+
+[Source Code](https://github.com/opendatakit/suitcase)
 
 ## ODK Sync-Endpoint
 Sync-Endpoint is a server that enables data to replicated between mobile devices. Sync-Endpoint runs in Docker and provides additional micro-services for authentication management. Requires [Docker](https://docs.docker.com/install/) and [Swarm](https://docs.docker.com/engine/swarm/swarm-tutorial/create-swarm/).
@@ -50,3 +60,10 @@ docker build --pull -t <orgname>/sync_endpoint https://github.com/opendatakit/sy
 ```
 
 For more detailed information and alternative Cloud Endpoints refer to the [documentation](https://docs.opendatakit.org/odk2/cloud-endpoints-intro/) 
+
+The source code for each of the Sync Endpoint services are available in these repositories:
+
+- [Sync Endpoint](https://github.com/opendatakit/sync-endpoint)
+- [Sync Endpoint Containers](https://github.com/opendatakit/sync-endpoint-containers)
+- [Sync Endpoint Web UI](https://github.com/opendatakit/sync-endpoint-web-ui)
+- [Sync Endpoint Default Setup](https://github.com/opendatakit/sync-endpoint-default-setup)

--- a/_pages/software/index.md
+++ b/_pages/software/index.md
@@ -28,8 +28,6 @@ ODK 1 tools are designed to be easier to use, require less setup, and are widely
 
 * [**XLSForm:**](http://docs.opendatakit.org/xlsform/) allows XForms to be designed with Excel.
 
-**Source code for all ODK 1 Suite products is available on [GitHub](https://github.com/opendatakit/opendatakit).**
-
 ## ODK 2 Suite: Information Management
 
 ODK 2 software is better suited for complex longitudinal studies and requires more technical skills. These tools are meant as next-generation solutions that will co-exist with existing ODK 1 tools. ODK 2 addresses several limitations of the existing ODK 1 Suite's data collection workflows such as:


### PR DESCRIPTION
Closes #76 and #69 

#### What is included in this PR?
As discussed in #69 the link to source code on the Software page is removed and individual links to each tool's source code are linked in their respective download sections. 

Also, as discussed in #76 the link to JavaRosa releases was broken, and is fixed in this PR.

#### What problems did you encounter?
XLSForm has 3 different repositories by my count. I tried to link all three in appropriate sections, but would appreciate review here. 

Build has online and offline versions. I linked to https://github.com/opendatakit/build. I am not sure if I need to link to another repository as well.

Sync Endpoint similarly has multiple repositories and all four are linked. This section needs work in general in my opinion, and I will create another issue around cleaning it up. I'm open to delaying the addition of these links to a future PR.



