### PR TITLE
Fix blog sharing images

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -199,7 +199,7 @@ defaults:
       author_profile: true
       read_time: true
       comments: false
-      share: true
+      share: false
       related: true
       sidebar:
         nav: "community"
@@ -219,7 +219,7 @@ defaults:
       layout: single
       read_time: true
       author_profile: true
-      share: true
+      share: false
       comments: false
       sidebar:
         nav: "community"

--- a/_config.yml
+++ b/_config.yml
@@ -16,9 +16,9 @@ title_separator          : "-"
 name                     : &name "ODK Community" # &name is a YAML anchor which can be *referenced later
 description              : &description "Home of the Open Data Kit software & community."
 url                      : "http://staging.opendatakit.org" # the base hostname & protocol for your site e.g. "https://mmistakes.github.io"
-baseurl                  : "" # the subpath of your site, e.g. "/blog"
+baseurl                  : # the subpath of your site, e.g. "/blog"
 repository               : "opendatakit/website"
-teaser                   : "/assets/odk/banner.jpg" # path of fallback teaser image, e.g. "/assets/images/500x300.png"
+teaser                   : # path of fallback teaser image, e.g. "/assets/images/500x300.png"
 # breadcrumbs            : false # true, false (default)
 words_per_minute         : 200
 comments:


### PR DESCRIPTION
#### What is included in this PR?
Removes the background image from the bottom of blog posts
<img width="1010" alt="screen shot 2018-05-22 at 21 04 01" src="https://user-images.githubusercontent.com/32369/40402995-b8b405ce-5e03-11e8-841f-fe1010cf638c.png">

Removes the sharing icons
<img width="548" alt="screen shot 2018-05-22 at 21 04 16" src="https://user-images.githubusercontent.com/32369/40403003-c8a214d0-5e03-11e8-8df6-33fbb067e16c.png">
