### PR TITLE
Remove all ToC to simply nav

### DIFF
--- a/_pages/blog/index.html
+++ b/_pages/blog/index.html
@@ -3,7 +3,6 @@ title: ODK Community Blog
 date: 2018-03-01T00:00:00+00:00
 layout: archive
 permalink: /blog/
-toc: true
 author_profile: true
 sidebar:
   nav: "community"

--- a/_pages/community/ecosystem.md
+++ b/_pages/community/ecosystem.md
@@ -3,7 +3,6 @@ title: Ecosystem
 date: 2018-03-23T00:00:00+00:00
 author_profile: false
 layout: single
-toc: true
 permalink: /community/ecosystem/
 sidebar:
   nav: "community"

--- a/_pages/community/governance.md
+++ b/_pages/community/governance.md
@@ -3,7 +3,6 @@ title: Community Governance
 date: 2018-03-01T00:00:00+00:00
 author_profile: false
 layout: single
-toc: true
 permalink: /community/governance/
 sidebar:
   nav: "community"

--- a/_pages/community/history.md
+++ b/_pages/community/history.md
@@ -6,7 +6,6 @@ layout: single
 permalink: /community/history
 sidebar:
   nav: "community"
-toc: true
 ---
 
 Open Data Kit (or ODK for short) is an open-source suite of tools that helps organizations author, collect, and manage mobile data collection solutions. Our goals are to make open-source and standards-based tools which are easy to try, easy to use, easy to modify and easy to scale. To this end, we are proud members of the  OpenRosa Consortium and active participants in the [JavaRosa](https://bitbucket.org/javarosa/javarosa/wiki/Home) project.

--- a/_pages/community/research.md
+++ b/_pages/community/research.md
@@ -7,10 +7,6 @@ sidebar:
   nav: "community"
 permalink: /community/research/
 
-toc: true
-toc_label: "Research"
-toc_icon: "graduation-cap"
-
 ---
 
 Open Data Kit is a research platform for the Department of Computer Science & Engineering at the University of Washington. The community disseminates our work through academic as well as the [popular press](/about/#press).

--- a/_pages/software/odk1.md
+++ b/_pages/software/odk1.md
@@ -5,10 +5,6 @@ author_profile: false
 layout: single
 permalink: /software/odk1/
 
-toc: true
-toc_label: ODK 1
-toc_icon: "download"
-
 sidebar:
   nav: "software"
 

--- a/_pages/software/odk2.md
+++ b/_pages/software/odk2.md
@@ -4,9 +4,6 @@ date: 2018-03-01T00:00:00+00:00
 author_profile: false
 layout: single
 permalink: /software/odk2/
-toc: true
-toc_label: ODK 2
-toc_icon: "download"
 sidebar:
   nav: "software"
 


### PR DESCRIPTION
Addresses #87

#### What is included in this PR?
The ToC makes the navigation complex. We might be able to improve this later (e.g., for history and research pages), but for now, I think removing them makes things simpler.