### PR TITLE
WIP: Deployments page as RSS feed from forum

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source "https://rubygems.org"
 
 gem "minimal-mistakes-jekyll"
 gem "html-proofer"
+gem "feedjira"

--- a/_config.yml
+++ b/_config.yml
@@ -184,6 +184,8 @@ kramdown:
 
 # Collections
 collections:
+  deployments_feed:
+    output: false
   docs:
     output: true
     permalink: /:collection/:path/

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -22,6 +22,8 @@ community:
     children:
     - title: "Blog"
       url: /blog/
+    - title: "Deployments"
+      url: /community/deployments/
     - title: "Ecosystem"
       url: /community/ecosystem/
     - title: "Governance"

--- a/_pages/community/deployments.md
+++ b/_pages/community/deployments.md
@@ -1,0 +1,15 @@
+---
+title: Deployments Showcase 
+author_profile: false
+permalink: /community/deployments/
+sidebar:
+  nav: "community"
+---
+
+<h3>from the <a href="https://forum.opendatakit.org/c/showcase">ODK Forum's Showcase</a></h3>
+<section id="main" class="wrapper style1">
+  {% for entry in site.deployments_feed %}
+    <h2>{{ entry.title }}</h2>
+    <p>{{ entry.feed_content }}</p>
+  {% endfor %}
+</section>

--- a/_plugins/deployments_rss_reader.rb
+++ b/_plugins/deployments_rss_reader.rb
@@ -1,0 +1,25 @@
+require 'feedjira'
+
+module Jekyll
+  class DeploymentsRssReader < Generator
+    safe true
+    priority :high
+
+def generate(site)
+      deployments_rss_collection = Jekyll::Collection.new(site, 'deployments_feed')
+      site.collections['deployments_feed'] = deployments_rss_collection
+	  url = "https://forum.opendatakit.org/c/showcase.rss"
+	  feed = Feedjira::Feed.fetch_and_parse url
+		
+	  feed.entries.each do |entry|
+		title = entry[:title]
+		#a proper path should be unnecessary since output is turned off in _config.yml, left in case someone turns on
+        path = site.in_source_dir("./_contribution_feed/" + title + ".md") 
+        doc = Jekyll::Document.new(path, { :site => site, :collection => deployments_rss_collection })
+        doc.data['title'] = title;
+        doc.data['feed_content'] = entry[:summary];
+        deployments_rss_collection.docs << doc
+      end
+    end
+  end
+end


### PR DESCRIPTION
Addresses #102 

#### What is included in this PR?
This PR replaces the deployments page with an RSS feed from the ODK Forum. 

This PR is a WIP (Work-In-Progress) as feedback about the new way of updating the website should be considered.

Two initial issues:
1) As the WIP demonstrates when just getting the showcase RSS we get interviews and other forum things. This could be mitigated by creating a sub-category "deployments" and enabling us to limit to posts that have been categorized as a deployment. Thoughts?
2) A GitHub based Jekyll website is a set of static pages therefore the pages do not fetch the most recent RSS entries without rebuilding. This could be mitigated by having CircleCI rebuild on a regular cycle (e.g., 24 hours) enabling the updates to occur automatically. Thoughts?

