### PR TITLE
fixes blog urls

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,7 +24,8 @@ words_per_minute         : 200
 comments:
   provider               : "discourse" # false (default), "disqus", "discourse", "facebook", "google-plus", "staticman_v2", "staticman" "custom"
   disqus:
-    shortname            :
+
+shortname            :
   discourse:
     server               : # https://meta.discourse.org/t/embedding-discourse-comments-via-javascript/31963 , e.g.: meta.discourse.org
   facebook:
@@ -195,6 +196,7 @@ defaults:
       path: ""
       type: posts
     values:
+      permalink: /:year/:month/:title/
       layout: single
       author_profile: true
       read_time: true

--- a/_posts/2011-01-11-open-data-kit-named-wtia-industry-achievement-award-finalist.md
+++ b/_posts/2011-01-11-open-data-kit-named-wtia-industry-achievement-award-finalist.md
@@ -5,7 +5,6 @@ date: 2011-01-11T03:33:05+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=669
-permalink: /2011/01/11/open-data-kit-named-wtia-industry-achievement-award-finalist/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2011-01-21-676.md
+++ b/_posts/2011-01-21-676.md
@@ -5,7 +5,6 @@ date: 2011-01-21T00:46:13+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=676
-permalink: /2011/01/21/676/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2011-02-15-community-created-training-guides-for-odk.md
+++ b/_posts/2011-02-15-community-created-training-guides-for-odk.md
@@ -5,7 +5,6 @@ date: 2011-02-15T15:19:48+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=688
-permalink: /2011/02/15/community-created-training-guides-for-odk/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2011-02-16-an-odk-success-story-from-afghanistan.md
+++ b/_posts/2011-02-16-an-odk-success-story-from-afghanistan.md
@@ -5,7 +5,6 @@ date: 2011-02-16T22:07:33+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=703
-permalink: /2011/02/16/an-odk-success-story-from-afghanistan/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2011-02-25-odk-wins-wtia-industry-achievement-award.md
+++ b/_posts/2011-02-25-odk-wins-wtia-industry-achievement-award.md
@@ -5,7 +5,6 @@ date: 2011-02-25T04:42:42+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=721
-permalink: /2011/02/25/odk-wins-wtia-industry-achievement-award/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2011-03-03-odk-deployment-survey.md
+++ b/_posts/2011-03-03-odk-deployment-survey.md
@@ -5,7 +5,6 @@ date: 2011-03-03T23:17:06+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=750
-permalink: /2011/03/03/odk-deployment-survey/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2011-03-26-training-videos-from-ehealth-nigeria.md
+++ b/_posts/2011-03-26-training-videos-from-ehealth-nigeria.md
@@ -5,7 +5,6 @@ date: 2011-03-26T02:56:27+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=956
-permalink: /2011/03/26/training-videos-from-ehealth-nigeria/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2011-04-06-donate-to-the-odk-project.md
+++ b/_posts/2011-04-06-donate-to-the-odk-project.md
@@ -5,7 +5,6 @@ date: 2011-04-06T03:22:53+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=967
-permalink: /2011/04/06/donate-to-the-odk-project/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2011-04-17-uw-engineering-and-odk.md
+++ b/_posts/2011-04-17-uw-engineering-and-odk.md
@@ -5,7 +5,6 @@ date: 2011-04-17T00:57:29+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=987
-permalink: /2011/04/17/uw-engineering-and-odk/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2011-04-27-using-odk-for-egra-data-collection.md
+++ b/_posts/2011-04-27-using-odk-for-egra-data-collection.md
@@ -5,7 +5,6 @@ date: 2011-04-27T15:18:25+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=996
-permalink: /2011/04/27/using-odk-for-egra-data-collection/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2011-04-29-measuring-observations-of-daily-living-with-odk.md
+++ b/_posts/2011-04-29-measuring-observations-of-daily-living-with-odk.md
@@ -5,7 +5,6 @@ date: 2011-04-29T23:21:12+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=1013
-permalink: /2011/04/29/measuring-observations-of-daily-living-with-odk/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2011-05-03-form-sharing-with-odk-build.md
+++ b/_posts/2011-05-03-form-sharing-with-odk-build.md
@@ -5,7 +5,6 @@ date: 2011-05-03T13:41:58+00:00
 author: Clint Tseng
 layout: single
 guid: /?p=1022
-permalink: /2011/05/03/form-sharing-with-odk-build/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2011-05-09-carbon-for-water-collects-40000-forms-per-day-with-odk-and-monitors-results-from-international-space-station.md
+++ b/_posts/2011-05-09-carbon-for-water-collects-40000-forms-per-day-with-odk-and-monitors-results-from-international-space-station.md
@@ -5,7 +5,6 @@ date: 2011-05-09T18:30:00+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=1031
-permalink: /2011/05/09/carbon-for-water-collects-40000-forms-per-day-with-odk-and-monitors-results-from-international-space-station/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2011-05-13-advancing-the-new-machine-mobile-technology-panel.md
+++ b/_posts/2011-05-13-advancing-the-new-machine-mobile-technology-panel.md
@@ -5,7 +5,6 @@ date: 2011-05-13T16:05:34+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=1105
-permalink: /2011/05/13/advancing-the-new-machine-mobile-technology-panel/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2011-05-24-mhealth-solution-with-odk-and-drupal-7.md
+++ b/_posts/2011-05-24-mhealth-solution-with-odk-and-drupal-7.md
@@ -5,7 +5,6 @@ date: 2011-05-24T14:57:10+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=1128
-permalink: /2011/05/24/mhealth-solution-with-odk-and-drupal-7/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2011-06-10-collect-1-1-7-and-aggregate-1-0-betas-released.md
+++ b/_posts/2011-06-10-collect-1-1-7-and-aggregate-1-0-betas-released.md
@@ -5,7 +5,6 @@ date: 2011-06-10T16:49:53+00:00
 author: Carl Hartung
 layout: single
 guid: /?p=1145
-permalink: /2011/06/10/collect-1-1-7-and-aggregate-1-0-betas-released/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2011-06-14-collect-1-1-7-beta-2-released.md
+++ b/_posts/2011-06-14-collect-1-1-7-beta-2-released.md
@@ -5,7 +5,6 @@ date: 2011-06-14T20:06:56+00:00
 author: Carl Hartung
 layout: single
 guid: /?p=1153
-permalink: /2011/06/14/collect-1-1-7-beta-2-released/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2011-06-20-validate-v1-4-released.md
+++ b/_posts/2011-06-20-validate-v1-4-released.md
@@ -5,7 +5,6 @@ date: 2011-06-20T14:44:25+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=1159
-permalink: /2011/06/20/validate-v1-4-released/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2011-06-23-odk-chatroom-goes-live.md
+++ b/_posts/2011-06-23-odk-chatroom-goes-live.md
@@ -5,7 +5,6 @@ date: 2011-06-23T12:01:56+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=1171
-permalink: /2011/06/23/odk-chatroom-goes-live/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2011-07-05-odk-for-community-based-forest-monitoring.md
+++ b/_posts/2011-07-05-odk-for-community-based-forest-monitoring.md
@@ -5,7 +5,6 @@ date: 2011-07-05T10:00:25+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=1188
-permalink: /2011/07/05/odk-for-community-based-forest-monitoring/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2011-07-13-using-odk-with-postgis-geoserver-and-leaflet.md
+++ b/_posts/2011-07-13-using-odk-with-postgis-geoserver-and-leaflet.md
@@ -5,7 +5,6 @@ date: 2011-07-13T08:00:45+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=1237
-permalink: /2011/07/13/using-odk-with-postgis-geoserver-and-leaflet/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2011-07-24-collect-1-1-7-rc1-and-aggregate-1-0-%ce%b23-released.md
+++ b/_posts/2011-07-24-collect-1-1-7-rc1-and-aggregate-1-0-%ce%b23-released.md
@@ -5,7 +5,6 @@ date: 2011-07-24T15:51:50+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=1332
-permalink: '/2011/07/24/collect-1-1-7-rc1-and-aggregate-1-0-%ce%b23-released/'
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2011-07-26-experiences-with-kobo-and-odk-in-bolivia.md
+++ b/_posts/2011-07-26-experiences-with-kobo-and-odk-in-bolivia.md
@@ -5,7 +5,6 @@ date: 2011-07-26T09:00:11+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=1256
-permalink: /2011/07/26/experiences-with-kobo-and-odk-in-bolivia/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2011-08-01-using-odk-to-enroll-patients-for-primary-health-care-in-india.md
+++ b/_posts/2011-08-01-using-odk-to-enroll-patients-for-primary-health-care-in-india.md
@@ -5,7 +5,6 @@ date: 2011-08-01T08:00:12+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=1359
-permalink: /2011/08/01/using-odk-to-enroll-patients-for-primary-health-care-in-india/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2011-08-03-urgent-need-for-odk-assistance-east-africa-famine.md
+++ b/_posts/2011-08-03-urgent-need-for-odk-assistance-east-africa-famine.md
@@ -5,7 +5,6 @@ date: 2011-08-03T18:56:10+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=1383
-permalink: /2011/08/03/urgent-need-for-odk-assistance-east-africa-famine/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2011-08-08-odk-used-for-expanding-financial-services-for-the-poor.md
+++ b/_posts/2011-08-08-odk-used-for-expanding-financial-services-for-the-poor.md
@@ -5,7 +5,6 @@ date: 2011-08-08T06:00:35+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=1373
-permalink: /2011/08/08/odk-used-for-expanding-financial-services-for-the-poor/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2011-08-10-odk-xls2xform-helps-users-design-xforms-using-excel.md
+++ b/_posts/2011-08-10-odk-xls2xform-helps-users-design-xforms-using-excel.md
@@ -5,7 +5,6 @@ date: 2011-08-10T16:21:30+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=1414
-permalink: /2011/08/10/odk-xls2xform-helps-users-design-xforms-using-excel/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2011-08-15-lymphatic-filariasis-reduction-with-lfsc-and-odk.md
+++ b/_posts/2011-08-15-lymphatic-filariasis-reduction-with-lfsc-and-odk.md
@@ -5,7 +5,6 @@ date: 2011-08-15T08:00:11+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=1391
-permalink: /2011/08/15/lymphatic-filariasis-reduction-with-lfsc-and-odk/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2011-08-29-mapping-700-tourist-sites-on-bohol-island-with-odk.md
+++ b/_posts/2011-08-29-mapping-700-tourist-sites-on-bohol-island-with-odk.md
@@ -5,7 +5,6 @@ date: 2011-08-29T08:00:07+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=1443
-permalink: /2011/08/29/mapping-700-tourist-sites-on-bohol-island-with-odk/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2011-09-03-list-of-odk-implementation-companies.md
+++ b/_posts/2011-09-03-list-of-odk-implementation-companies.md
@@ -5,7 +5,6 @@ date: 2011-09-03T00:00:49+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=1481
-permalink: /2011/09/03/list-of-odk-implementation-companies/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2011-09-08-odk-used-for-epidemiology-study-in-brazil.md
+++ b/_posts/2011-09-08-odk-used-for-epidemiology-study-in-brazil.md
@@ -5,7 +5,6 @@ date: 2011-09-08T08:00:48+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=735
-permalink: /2011/09/08/odk-used-for-epidemiology-study-in-brazil/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2011-09-13-mapping-soil-conditions-in-africa-with-odk.md
+++ b/_posts/2011-09-13-mapping-soil-conditions-in-africa-with-odk.md
@@ -5,7 +5,6 @@ date: 2011-09-13T08:00:59+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=1475
-permalink: /2011/09/13/mapping-soil-conditions-in-africa-with-odk/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2011-09-15-video-interview-with-clinicians-using-odk-in-nigeria.md
+++ b/_posts/2011-09-15-video-interview-with-clinicians-using-odk-in-nigeria.md
@@ -5,7 +5,6 @@ date: 2011-09-15T00:00:51+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=1508
-permalink: /2011/09/15/video-interview-with-clinicians-using-odk-in-nigeria/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2011-09-21-new-york-city-using-odk-for-health-operations.md
+++ b/_posts/2011-09-21-new-york-city-using-odk-for-health-operations.md
@@ -5,7 +5,6 @@ date: 2011-09-21T22:22:00+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=1576
-permalink: /2011/09/21/new-york-city-using-odk-for-health-operations/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2011-10-03-viewworlds-training-videos-for-odk-build.md
+++ b/_posts/2011-10-03-viewworlds-training-videos-for-odk-build.md
@@ -5,7 +5,6 @@ date: 2011-10-03T08:13:29+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=1506
-permalink: /2011/10/03/viewworlds-training-videos-for-odk-build/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2011-10-11-video-interview-with-enumerators-in-tanzania.md
+++ b/_posts/2011-10-11-video-interview-with-enumerators-in-tanzania.md
@@ -5,7 +5,6 @@ date: 2011-10-11T15:14:01+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=1639
-permalink: /2011/10/11/video-interview-with-enumerators-in-tanzania/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2011-10-14-wisconsin-using-odk-for-natural-disaster-assessments.md
+++ b/_posts/2011-10-14-wisconsin-using-odk-for-natural-disaster-assessments.md
@@ -5,7 +5,6 @@ date: 2011-10-14T05:21:29+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=1617
-permalink: /2011/10/14/wisconsin-using-odk-for-natural-disaster-assessments/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2011-10-20-using-odk-to-improve-maternal-care-in-ethiopia.md
+++ b/_posts/2011-10-20-using-odk-to-improve-maternal-care-in-ethiopia.md
@@ -5,7 +5,6 @@ date: 2011-10-20T15:25:41+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=1685
-permalink: /2011/10/20/using-odk-to-improve-maternal-care-in-ethiopia/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2011-10-27-punjab-government-monitoring-health-officials-with-odk.md
+++ b/_posts/2011-10-27-punjab-government-monitoring-health-officials-with-odk.md
@@ -5,7 +5,6 @@ date: 2011-10-27T19:05:27+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=1714
-permalink: /2011/10/27/punjab-government-monitoring-health-officials-with-odk/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2011-11-09-odk-projects-nominated-in-healthunbounds-innovators-challenge.md
+++ b/_posts/2011-11-09-odk-projects-nominated-in-healthunbounds-innovators-challenge.md
@@ -5,7 +5,6 @@ date: 2011-11-09T05:01:52+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=2043
-permalink: /2011/11/09/odk-projects-nominated-in-healthunbounds-innovators-challenge/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2011-12-01-odk-collect-1-1-7-released.md
+++ b/_posts/2011-12-01-odk-collect-1-1-7-released.md
@@ -5,7 +5,6 @@ date: 2011-12-01T23:15:17+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=2088
-permalink: /2011/12/01/odk-collect-1-1-7-released/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2011-12-05-odk-aggregate-1-0-2-released.md
+++ b/_posts/2011-12-05-odk-aggregate-1-0-2-released.md
@@ -5,7 +5,6 @@ date: 2011-12-05T06:00:23+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=2127
-permalink: /2011/12/05/odk-aggregate-1-0-2-released/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2011-12-06-odk-implementers-awarded-as-top-mhealth-innovators.md
+++ b/_posts/2011-12-06-odk-implementers-awarded-as-top-mhealth-innovators.md
@@ -5,7 +5,6 @@ date: 2011-12-06T04:02:27+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=2150
-permalink: /2011/12/06/odk-implementers-awarded-as-top-mhealth-innovators/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2011-12-08-introducing-formhub-free-hosted-data-service-for-odk-collect.md
+++ b/_posts/2011-12-08-introducing-formhub-free-hosted-data-service-for-odk-collect.md
@@ -5,7 +5,6 @@ date: 2011-12-08T06:07:01+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=2176
-permalink: /2011/12/08/introducing-formhub-free-hosted-data-service-for-odk-collect/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2011-12-12-comparison-of-mobile-solutions-for-gis-data-collection-and-display.md
+++ b/_posts/2011-12-12-comparison-of-mobile-solutions-for-gis-data-collection-and-display.md
@@ -5,7 +5,6 @@ date: 2011-12-12T03:14:37+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=2106
-permalink: /2011/12/12/comparison-of-mobile-solutions-for-gis-data-collection-and-display/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2012-01-09-odk-used-to-measure-agricultural-losses-after-floods-in-haiti.md
+++ b/_posts/2012-01-09-odk-used-to-measure-agricultural-losses-after-floods-in-haiti.md
@@ -5,7 +5,6 @@ date: 2012-01-09T05:18:44+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=2186
-permalink: /2012/01/09/odk-used-to-measure-agricultural-losses-after-floods-in-haiti/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2012-01-18-bu-global-health-students-reflect-on-odk.md
+++ b/_posts/2012-01-18-bu-global-health-students-reflect-on-odk.md
@@ -5,7 +5,6 @@ date: 2012-01-18T07:28:09+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=2125
-permalink: /2012/01/18/bu-global-health-students-reflect-on-odk/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2012-01-24-ampath-improving-care-at-scale-with-odk-and-openmrs.md
+++ b/_posts/2012-01-24-ampath-improving-care-at-scale-with-odk-and-openmrs.md
@@ -5,7 +5,6 @@ date: 2012-01-24T16:16:30+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=2283
-permalink: /2012/01/24/ampath-improving-care-at-scale-with-odk-and-openmrs/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2012-03-08-xls2xform-is-now-xlsform.md
+++ b/_posts/2012-03-08-xls2xform-is-now-xlsform.md
@@ -5,7 +5,6 @@ date: 2012-03-08T02:06:42+00:00
 author: nabreit
 layout: single
 guid: /?p=2712
-permalink: /2012/03/08/xls2xform-is-now-xlsform/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2012-03-13-sarpam-using-odk-in-eight-countries-to-track-drug-availability.md
+++ b/_posts/2012-03-13-sarpam-using-odk-in-eight-countries-to-track-drug-availability.md
@@ -5,7 +5,6 @@ date: 2012-03-13T05:30:20+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=2659
-permalink: /2012/03/13/sarpam-using-odk-in-eight-countries-to-track-drug-availability/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2012-03-27-ipa-and-gates-using-odk-to-improve-safe-water-systems.md
+++ b/_posts/2012-03-27-ipa-and-gates-using-odk-to-improve-safe-water-systems.md
@@ -5,7 +5,6 @@ date: 2012-03-27T09:15:40+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=2729
-permalink: /2012/03/27/ipa-and-gates-using-odk-to-improve-safe-water-systems/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2012-04-04-updates-to-odk-aggregate-briefcase-form-uploader-and-validate-released.md
+++ b/_posts/2012-04-04-updates-to-odk-aggregate-briefcase-form-uploader-and-validate-released.md
@@ -5,7 +5,6 @@ date: 2012-04-04T22:44:03+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=2780
-permalink: /2012/04/04/updates-to-odk-aggregate-briefcase-form-uploader-and-validate-released/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2012-05-01-evaluating-reproductive-health-voucher-programs-with-odk.md
+++ b/_posts/2012-05-01-evaluating-reproductive-health-voucher-programs-with-odk.md
@@ -5,7 +5,6 @@ date: 2012-05-01T00:00:24+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=2801
-permalink: /2012/05/01/evaluating-reproductive-health-voucher-programs-with-odk/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2012-06-04-surui-tribe-in-the-amazon-using-odk.md
+++ b/_posts/2012-06-04-surui-tribe-in-the-amazon-using-odk.md
@@ -5,7 +5,6 @@ date: 2012-06-04T20:02:05+00:00
 author: Waylon Brunette
 layout: single
 guid: /?p=2930
-permalink: /2012/06/04/surui-tribe-in-the-amazon-using-odk/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2012-07-24-version-1-2-of-the-odk-tools-released.md
+++ b/_posts/2012-07-24-version-1-2-of-the-odk-tools-released.md
@@ -5,7 +5,6 @@ date: 2012-07-24T09:07:13+00:00
 author: Waylon Brunette
 layout: single
 guid: /?p=3000
-permalink: /2012/07/24/version-1-2-of-the-odk-tools-released/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2012-08-08-carter-center-using-odk-for-election-observation.md
+++ b/_posts/2012-08-08-carter-center-using-odk-for-election-observation.md
@@ -5,7 +5,6 @@ date: 2012-08-08T00:05:02+00:00
 author: Waylon Brunette
 layout: single
 guid: /?p=3047
-permalink: /2012/08/08/carter-center-using-odk-for-election-observation/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2012-08-28-odk-collect-1-2-1-released.md
+++ b/_posts/2012-08-28-odk-collect-1-2-1-released.md
@@ -5,7 +5,6 @@ date: 2012-08-28T23:50:52+00:00
 author: Waylon Brunette
 layout: single
 guid: /?p=3084
-permalink: /2012/08/28/odk-collect-1-2-1-released/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2012-09-14-user-input-to-help-odk-2-0-design.md
+++ b/_posts/2012-09-14-user-input-to-help-odk-2-0-design.md
@@ -5,7 +5,6 @@ date: 2012-09-14T19:47:50+00:00
 author: Waylon Brunette
 layout: single
 guid: /?p=3108
-permalink: /2012/09/14/user-input-to-help-odk-2-0-design/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2012-09-30-kiva-using-odk-in-kenya.md
+++ b/_posts/2012-09-30-kiva-using-odk-in-kenya.md
@@ -5,7 +5,6 @@ date: 2012-09-30T01:11:38+00:00
 author: Waylon Brunette
 layout: single
 guid: /?p=3114
-permalink: /2012/09/30/kiva-using-odk-in-kenya/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2012-10-18-africa-soil-information-service-using-odk.md
+++ b/_posts/2012-10-18-africa-soil-information-service-using-odk.md
@@ -5,7 +5,6 @@ date: 2012-10-18T22:53:10+00:00
 author: Waylon Brunette
 layout: single
 guid: /?p=3151
-permalink: /2012/10/18/africa-soil-information-service-using-odk/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2012-11-26-admin-mode-arrives-in-odk-collect-1-2-2.md
+++ b/_posts/2012-11-26-admin-mode-arrives-in-odk-collect-1-2-2.md
@@ -5,7 +5,6 @@ date: 2012-11-26T19:52:41+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=3210
-permalink: /2012/11/26/admin-mode-arrives-in-odk-collect-1-2-2/
 aktt_notify_twitter:
   - 'no'
 categories:

--- a/_posts/2013-01-14-metadata-outputs-and-calculates-in-odk-build.md
+++ b/_posts/2013-01-14-metadata-outputs-and-calculates-in-odk-build.md
@@ -5,7 +5,6 @@ date: 2013-01-14T05:08:57+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=3320
-permalink: /2013/01/14/metadata-outputs-and-calculates-in-odk-build/
 categories:
   - Uncategorized
 ---

--- a/_posts/2013-02-02-odk-aggregate-1-3-0-released.md
+++ b/_posts/2013-02-02-odk-aggregate-1-3-0-released.md
@@ -5,7 +5,6 @@ date: 2013-02-02T16:32:55+00:00
 author: Mitchell Sundt
 layout: single
 guid: /?p=3399
-permalink: /2013/02/02/odk-aggregate-1-3-0-released/
 categories:
   - Uncategorized
 ---

--- a/_posts/2013-02-04-announcing-the-odk-aggregate-vm.md
+++ b/_posts/2013-02-04-announcing-the-odk-aggregate-vm.md
@@ -5,7 +5,6 @@ date: 2013-02-04T20:05:32+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=3425
-permalink: /2013/02/04/announcing-the-odk-aggregate-vm/
 categories:
   - Uncategorized
 ---

--- a/_posts/2013-02-09-group-complete-mobile-is-now-open-source.md
+++ b/_posts/2013-02-09-group-complete-mobile-is-now-open-source.md
@@ -5,7 +5,6 @@ date: 2013-02-09T01:13:37+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=3468
-permalink: /2013/02/09/group-complete-mobile-is-now-open-source/
 categories:
   - Uncategorized
 ---

--- a/_posts/2013-02-12-protecting-the-amazon-rainforest-with-odk.md
+++ b/_posts/2013-02-12-protecting-the-amazon-rainforest-with-odk.md
@@ -5,7 +5,6 @@ date: 2013-02-12T16:01:08+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=3465
-permalink: /2013/02/12/protecting-the-amazon-rainforest-with-odk/
 categories:
   - Uncategorized
 ---

--- a/_posts/2013-02-27-a-sneak-peek-at-odks-future.md
+++ b/_posts/2013-02-27-a-sneak-peek-at-odks-future.md
@@ -5,7 +5,6 @@ date: 2013-02-27T16:40:52+00:00
 author: Waylon Brunette
 layout: single
 guid: /?p=3564
-permalink: /2013/02/27/a-sneak-peek-at-odks-future/
 categories:
   - Uncategorized
 ---

--- a/_posts/2013-04-12-updated-odk-tools-released-versions-1-3-and-2-0-alpha.md
+++ b/_posts/2013-04-12-updated-odk-tools-released-versions-1-3-and-2-0-alpha.md
@@ -5,7 +5,6 @@ date: 2013-04-12T22:57:09+00:00
 author: Waylon Brunette
 layout: single
 guid: /?p=3687
-permalink: /2013/04/12/updated-odk-tools-released-versions-1-3-and-2-0-alpha/
 categories:
   - Uncategorized
 ---

--- a/_posts/2013-04-22-nafundi-adds-auto-send-navigation-buttons-and-bulk-configuration-to-collect.md
+++ b/_posts/2013-04-22-nafundi-adds-auto-send-navigation-buttons-and-bulk-configuration-to-collect.md
@@ -5,7 +5,6 @@ date: 2013-04-22T17:56:30+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=3714
-permalink: /2013/04/22/nafundi-adds-auto-send-navigation-buttons-and-bulk-configuration-to-collect/
 categories:
   - Uncategorized
 ---

--- a/_posts/2013-05-14-nafundi-taskforce-and-grameen-showcase-odk-at-google-io.md
+++ b/_posts/2013-05-14-nafundi-taskforce-and-grameen-showcase-odk-at-google-io.md
@@ -5,7 +5,6 @@ date: 2013-05-14T05:00:32+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=3757
-permalink: /2013/05/14/nafundi-taskforce-and-grameen-showcase-odk-at-google-io/
 categories:
   - Uncategorized
 ---

--- a/_posts/2013-05-27-help-translate-odk-into-multiple-languages.md
+++ b/_posts/2013-05-27-help-translate-odk-into-multiple-languages.md
@@ -5,7 +5,6 @@ date: 2013-05-27T09:00:38+00:00
 author: Waylon Brunette
 layout: single
 guid: /?p=3816
-permalink: /2013/05/27/help-translate-odk-into-multiple-languages/
 categories:
   - Uncategorized
 ---

--- a/_posts/2013-06-11-task-force-and-nafundi-release-codebook-generator-for-odk.md
+++ b/_posts/2013-06-11-task-force-and-nafundi-release-codebook-generator-for-odk.md
@@ -5,7 +5,6 @@ date: 2013-06-11T08:00:24+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=3848
-permalink: /2013/06/11/task-force-and-nafundi-release-codebook-generator-for-odk/
 categories:
   - Uncategorized
 ---

--- a/_posts/2013-06-20-young-dare-devils-map-their-world-with-odk-and-formhub.md
+++ b/_posts/2013-06-20-young-dare-devils-map-their-world-with-odk-and-formhub.md
@@ -5,7 +5,6 @@ date: 2013-06-20T06:23:20+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=3892
-permalink: /2013/06/20/young-dare-devils-map-their-world-with-odk-and-formhub/
 categories:
   - Uncategorized
 ---

--- a/_posts/2013-07-08-odk-team-releases-odk-tables-alpha.md
+++ b/_posts/2013-07-08-odk-team-releases-odk-tables-alpha.md
@@ -5,7 +5,6 @@ date: 2013-07-08T16:19:31+00:00
 author: Sam Sudar
 layout: single
 guid: /?p=3915
-permalink: /2013/07/08/odk-team-releases-odk-tables-alpha/
 categories:
   - Uncategorized
 ---

--- a/_posts/2013-07-23-using-elmo-odk-in-kenyas-2013-presidential-elections.md
+++ b/_posts/2013-07-23-using-elmo-odk-in-kenyas-2013-presidential-elections.md
@@ -5,7 +5,6 @@ date: 2013-07-23T12:01:46+00:00
 author: Waylon Brunette
 layout: single
 guid: /?p=3984
-permalink: /2013/07/23/using-elmo-odk-in-kenyas-2013-presidential-elections/
 categories:
   - Uncategorized
 ---

--- a/_posts/2013-10-03-odk-releases-v1-4-tools.md
+++ b/_posts/2013-10-03-odk-releases-v1-4-tools.md
@@ -5,7 +5,6 @@ date: 2013-10-03T10:10:10+00:00
 author: Mitchell Sundt
 layout: single
 guid: /?p=4102
-permalink: /2013/10/03/odk-releases-v1-4-tools/
 categories:
   - Uncategorized
 ---

--- a/_posts/2013-10-11-odk-participates-in-grace-hopper-open-source-day-2013.md
+++ b/_posts/2013-10-11-odk-participates-in-grace-hopper-open-source-day-2013.md
@@ -5,7 +5,6 @@ date: 2013-10-11T13:50:42+00:00
 author: Waylon Brunette
 layout: single
 guid: /?p=4110
-permalink: /2013/10/11/odk-participates-in-grace-hopper-open-source-day-2013/
 categories:
   - Uncategorized
 ---

--- a/_posts/2013-11-23-odk-survey-2-0-beta-now-available.md
+++ b/_posts/2013-11-23-odk-survey-2-0-beta-now-available.md
@@ -5,7 +5,6 @@ date: 2013-11-23T16:15:21+00:00
 author: Mitchell Sundt
 layout: single
 guid: /?p=4188
-permalink: /2013/11/23/odk-survey-2-0-beta-now-available/
 categories:
   - Uncategorized
 ---

--- a/_posts/2014-02-08-new-download-page-for-opendatakit-tools.md
+++ b/_posts/2014-02-08-new-download-page-for-opendatakit-tools.md
@@ -5,7 +5,6 @@ date: 2014-02-08T06:02:13+00:00
 author: Mitchell Sundt
 layout: single
 guid: /?p=4593
-permalink: /2014/02/08/new-download-page-for-opendatakit-tools/
 categories:
   - Uncategorized
 ---

--- a/_posts/2014-02-08-odk-aggregate-1-4-1-with-enketo-webforms-integration-is-now-available.md
+++ b/_posts/2014-02-08-odk-aggregate-1-4-1-with-enketo-webforms-integration-is-now-available.md
@@ -5,7 +5,6 @@ date: 2014-02-08T06:36:32+00:00
 author: Mitchell Sundt
 layout: single
 guid: /?p=4595
-permalink: /2014/02/08/odk-aggregate-1-4-1-with-enketo-webforms-integration-is-now-available/
 categories:
   - Uncategorized
 ---

--- a/_posts/2014-03-12-profile-saloni-parikh-uw-undergraduate-and-odk-implementer.md
+++ b/_posts/2014-03-12-profile-saloni-parikh-uw-undergraduate-and-odk-implementer.md
@@ -5,7 +5,6 @@ date: 2014-03-12T18:57:21+00:00
 author: Waylon Brunette
 layout: single
 guid: /?p=4860
-permalink: /2014/03/12/profile-saloni-parikh-uw-undergraduate-and-odk-implementer/
 categories:
   - Uncategorized
 ---

--- a/_posts/2014-04-13-cgiars-climate-change-agriculture-and-food-security-with-odk.md
+++ b/_posts/2014-04-13-cgiars-climate-change-agriculture-and-food-security-with-odk.md
@@ -5,7 +5,6 @@ date: 2014-04-13T13:55:58+00:00
 author: Waylon Brunette
 layout: single
 guid: /?p=4924
-permalink: /2014/04/13/cgiars-climate-change-agriculture-and-food-security-with-odk/
 categories:
   - Uncategorized
 ---

--- a/_posts/2014-05-13-when-innovation-leads-to-a-low-tech-solution.md
+++ b/_posts/2014-05-13-when-innovation-leads-to-a-low-tech-solution.md
@@ -5,7 +5,6 @@ date: 2014-05-13T13:46:53+00:00
 author: Waylon Brunette
 layout: single
 guid: /?p=4981
-permalink: /2014/05/13/when-innovation-leads-to-a-low-tech-solution/
 categories:
   - Uncategorized
 ---

--- a/_posts/2014-05-27-ampath-reaches-one-millionth-person.md
+++ b/_posts/2014-05-27-ampath-reaches-one-millionth-person.md
@@ -5,7 +5,6 @@ date: 2014-05-27T17:56:51+00:00
 author: Yaw Anokwa
 layout: single
 guid: /?p=5018
-permalink: /2014/05/27/ampath-reaches-one-millionth-person/
 categories:
   - Uncategorized
 ---

--- a/_posts/2014-07-07-odk-opens-door-to-improved-survey-data-for-agriculture.md
+++ b/_posts/2014-07-07-odk-opens-door-to-improved-survey-data-for-agriculture.md
@@ -5,7 +5,6 @@ date: 2014-07-07T18:20:16+00:00
 author: Waylon Brunette
 layout: single
 guid: /?p=5082
-permalink: /2014/07/07/odk-opens-door-to-improved-survey-data-for-agriculture/
 categories:
   - Uncategorized
 ---

--- a/_posts/2014-07-25-philippine-red-cross-uses-odk-for-its-community-health-activities.md
+++ b/_posts/2014-07-25-philippine-red-cross-uses-odk-for-its-community-health-activities.md
@@ -5,7 +5,6 @@ date: 2014-07-25T16:55:24+00:00
 author: Waylon Brunette
 layout: single
 guid: /?p=5110
-permalink: /2014/07/25/philippine-red-cross-uses-odk-for-its-community-health-activities/
 categories:
   - Uncategorized
 ---

--- a/_posts/2014-08-29-odk-v1-4-4-tools-now-available.md
+++ b/_posts/2014-08-29-odk-v1-4-4-tools-now-available.md
@@ -5,7 +5,6 @@ date: 2014-08-29T16:24:38+00:00
 author: Mitchell Sundt
 layout: single
 guid: /?p=5660
-permalink: /2014/08/29/odk-v1-4-4-tools-now-available/
 categories:
   - Uncategorized
 ---

--- a/_posts/2014-09-02-odk-2-0-alpha-rev-122-now-available.md
+++ b/_posts/2014-09-02-odk-2-0-alpha-rev-122-now-available.md
@@ -5,7 +5,6 @@ date: 2014-09-02T17:11:56+00:00
 author: Mitchell Sundt
 layout: single
 guid: /?p=5748
-permalink: /2014/09/02/odk-2-0-alpha-rev-122-now-available/
 categories:
   - Uncategorized
 ---

--- a/_posts/2015-01-06-using-odk-in-nahr-el-bared-camp-lebanon.md
+++ b/_posts/2015-01-06-using-odk-in-nahr-el-bared-camp-lebanon.md
@@ -5,7 +5,6 @@ date: 2015-01-06T13:19:08+00:00
 author: Waylon Brunette
 layout: single
 guid: https://opendatakit.org/?p=5981
-permalink: /2015/01/06/using-odk-in-nahr-el-bared-camp-lebanon/
 categories:
   - Uncategorized
 ---

--- a/_posts/2015-01-13-odk-1-4-5-released-major-enhancement-to-odk-collect.md
+++ b/_posts/2015-01-13-odk-1-4-5-released-major-enhancement-to-odk-collect.md
@@ -5,7 +5,6 @@ date: 2015-01-13T15:01:21+00:00
 author: Mitchell Sundt
 layout: single
 guid: https://opendatakit.org/?p=6014
-permalink: /2015/01/13/odk-1-4-5-released-major-enhancement-to-odk-collect/
 categories:
   - Uncategorized
 ---

--- a/_posts/2015-01-22-collecting-50-million-data-points-across-200-projects-in-40-countries.md
+++ b/_posts/2015-01-22-collecting-50-million-data-points-across-200-projects-in-40-countries.md
@@ -5,7 +5,6 @@ date: 2015-01-22T12:57:21+00:00
 author: Waylon Brunette
 layout: single
 guid: https://opendatakit.org/?p=6054
-permalink: /2015/01/22/collecting-50-million-data-points-across-200-projects-in-40-countries/
 categories:
   - Uncategorized
 ---

--- a/_posts/2015-02-01-remembering-gaetano-borriello.md
+++ b/_posts/2015-02-01-remembering-gaetano-borriello.md
@@ -5,7 +5,6 @@ date: 2015-02-01T14:08:31+00:00
 author: Waylon Brunette
 layout: single
 guid: https://opendatakit.org/?p=6096
-permalink: /2015/02/01/remembering-gaetano-borriello/
 categories:
   - Uncategorized
 ---

--- a/_posts/2015-03-01-reducing-errors-and-delays-in-collecting-millions-of-world-food-programme-data-points.md
+++ b/_posts/2015-03-01-reducing-errors-and-delays-in-collecting-millions-of-world-food-programme-data-points.md
@@ -5,7 +5,6 @@ date: 2015-03-01T11:10:45+00:00
 author: Waylon Brunette
 layout: single
 guid: https://opendatakit.org/?p=6361
-permalink: /2015/03/01/reducing-errors-and-delays-in-collecting-millions-of-world-food-programme-data-points/
 categories:
   - Uncategorized
 ---

--- a/_posts/2015-03-13-openfn-provides-integration-between-odk-and-safesforce.md
+++ b/_posts/2015-03-13-openfn-provides-integration-between-odk-and-safesforce.md
@@ -5,7 +5,6 @@ date: 2015-03-13T12:32:51+00:00
 author: Waylon Brunette
 layout: single
 guid: https://opendatakit.org/?p=6395
-permalink: /2015/03/13/openfn-provides-integration-between-odk-and-safesforce/
 categories:
   - Uncategorized
 ---

--- a/_posts/2015-03-26-finding-and-fixing-vacant-properties-through-crowdsourced-data-collection.md
+++ b/_posts/2015-03-26-finding-and-fixing-vacant-properties-through-crowdsourced-data-collection.md
@@ -5,7 +5,6 @@ date: 2015-03-26T10:00:38+00:00
 author: Waylon Brunette
 layout: single
 guid: https://opendatakit.org/?p=6380
-permalink: /2015/03/26/finding-and-fixing-vacant-properties-through-crowdsourced-data-collection/
 categories:
   - Uncategorized
 ---

--- a/_posts/2015-03-31-urgent-action-required-by-april-19th.md
+++ b/_posts/2015-03-31-urgent-action-required-by-april-19th.md
@@ -5,7 +5,6 @@ date: 2015-03-31T17:57:15+00:00
 author: Mitchell Sundt
 layout: single
 guid: https://opendatakit.org/?p=6412
-permalink: /2015/03/31/urgent-action-required-by-april-19th/
 categories:
   - Uncategorized
 ---

--- a/_posts/2015-04-07-from-the-ground-to-the-cloud-forest-monitoring-in-hutan-aceh.md
+++ b/_posts/2015-04-07-from-the-ground-to-the-cloud-forest-monitoring-in-hutan-aceh.md
@@ -5,7 +5,6 @@ date: 2015-04-07T10:00:26+00:00
 author: Yaw Anokwa
 layout: single
 guid: https://opendatakit.org/?p=6384
-permalink: /2015/04/07/from-the-ground-to-the-cloud-forest-monitoring-in-hutan-aceh/
 categories:
   - Uncategorized
 ---

--- a/_posts/2015-06-16-nafundis-yaw-anokwa-honored-by-university-of-washington-for-his-work-on-open-data-kit.md
+++ b/_posts/2015-06-16-nafundis-yaw-anokwa-honored-by-university-of-washington-for-his-work-on-open-data-kit.md
@@ -5,7 +5,6 @@ date: 2015-06-16T08:00:12+00:00
 author: Carl Hartung
 layout: single
 guid: https://opendatakit.org/?p=6501
-permalink: /2015/06/16/nafundis-yaw-anokwa-honored-by-university-of-washington-for-his-work-on-open-data-kit/
 categories:
   - Uncategorized
 ---

--- a/_posts/2015-07-08-xlsform-offline-and-odk-aggregate-vm-are-now-free.md
+++ b/_posts/2015-07-08-xlsform-offline-and-odk-aggregate-vm-are-now-free.md
@@ -5,7 +5,6 @@ date: 2015-07-08T08:01:52+00:00
 author: Waylon Brunette
 layout: single
 guid: https://opendatakit.org/?p=6585
-permalink: /2015/07/08/xlsform-offline-and-odk-aggregate-vm-are-now-free/
 categories:
   - Uncategorized
 ---

--- a/_posts/2015-09-22-join-nafundi-and-awhere-for-data-collection-hackathon-in-nairobi-on-oct-16th.md
+++ b/_posts/2015-09-22-join-nafundi-and-awhere-for-data-collection-hackathon-in-nairobi-on-oct-16th.md
@@ -5,7 +5,6 @@ date: 2015-09-22T12:00:16+00:00
 author: Waylon Brunette
 layout: single
 guid: https://opendatakit.org/?p=6715
-permalink: /2015/09/22/join-nafundi-and-awhere-for-data-collection-hackathon-in-nairobi-on-oct-16th/
 categories:
   - Uncategorized
 ---

--- a/_posts/2015-10-01-announcing-the-odk-discussion-series.md
+++ b/_posts/2015-10-01-announcing-the-odk-discussion-series.md
@@ -5,7 +5,6 @@ date: 2015-10-01T21:25:49+00:00
 author: Yaw Anokwa
 layout: single
 guid: https://opendatakit.org/?p=6725
-permalink: /2015/10/01/announcing-the-odk-discussion-series/
 categories:
   - Uncategorized
 ---

--- a/_posts/2015-11-18-uw-cse-and-nafundi-share-600k-grant-to-improve-open-data-kit.md
+++ b/_posts/2015-11-18-uw-cse-and-nafundi-share-600k-grant-to-improve-open-data-kit.md
@@ -5,7 +5,6 @@ date: 2015-11-18T18:06:55+00:00
 author: Yaw Anokwa
 layout: single
 guid: https://opendatakit.org/?p=6795
-permalink: /2015/11/18/uw-cse-and-nafundi-share-600k-grant-to-improve-open-data-kit/
 categories:
   - Uncategorized
 ---

--- a/_posts/2016-04-20-improving-polio-campaign-quality-in-jordan-somalia-and-south-sudan.md
+++ b/_posts/2016-04-20-improving-polio-campaign-quality-in-jordan-somalia-and-south-sudan.md
@@ -5,7 +5,6 @@ date: 2016-04-20T10:00:00+00:00
 author: Yaw Anokwa
 layout: single
 guid: https://opendatakit.org/?p=7107
-permalink: /2016/04/20/improving-polio-campaign-quality-in-jordan-somalia-and-south-sudan/
 categories:
   - Uncategorized
 ---

--- a/_posts/2016-05-04-participants-of-cardiff-university-sepsis-study-find-odk-reliable-fast-and-easy-to-use.md
+++ b/_posts/2016-05-04-participants-of-cardiff-university-sepsis-study-find-odk-reliable-fast-and-easy-to-use.md
@@ -5,7 +5,6 @@ date: 2016-05-04T00:05:40+00:00
 author: Yaw Anokwa
 layout: single
 guid: https://opendatakit.org/?p=7261
-permalink: /2016/05/04/participants-of-cardiff-university-sepsis-study-find-odk-reliable-fast-and-easy-to-use/
 categories:
   - Uncategorized
 ---

--- a/_posts/2016-05-17-odk-use-in-african-primate-conservation.md
+++ b/_posts/2016-05-17-odk-use-in-african-primate-conservation.md
@@ -5,7 +5,6 @@ date: 2016-05-17T07:30:13+00:00
 author: Yaw Anokwa
 layout: single
 guid: https://opendatakit.org/?p=7268
-permalink: /2016/05/17/odk-use-in-african-primate-conservation/
 categories:
   - Uncategorized
 ---

--- a/_posts/2016-05-24-monitoring-water-and-food-security-in-eastern-indonesia.md
+++ b/_posts/2016-05-24-monitoring-water-and-food-security-in-eastern-indonesia.md
@@ -5,7 +5,6 @@ date: 2016-05-24T04:01:12+00:00
 author: Yaw Anokwa
 layout: single
 guid: https://opendatakit.org/?p=7439
-permalink: /2016/05/24/monitoring-water-and-food-security-in-eastern-indonesia/
 categories:
   - Uncategorized
 ---

--- a/_posts/2016-06-14-odk-usage-after-nepal-earthquake.md
+++ b/_posts/2016-06-14-odk-usage-after-nepal-earthquake.md
@@ -5,7 +5,6 @@ date: 2016-06-14T13:33:08+00:00
 author: Waylon Brunette
 layout: single
 guid: https://opendatakit.org/?p=7502
-permalink: /2016/06/14/odk-usage-after-nepal-earthquake/
 categories:
   - Uncategorized
 ---

--- a/_posts/2016-07-05-bolivian-red-cross-and-international-federation-of-red-cross-and-red-crescent-societies-use-odk-to-combat-zika.md
+++ b/_posts/2016-07-05-bolivian-red-cross-and-international-federation-of-red-cross-and-red-crescent-societies-use-odk-to-combat-zika.md
@@ -5,7 +5,6 @@ date: 2016-07-05T10:49:44+00:00
 author: Waylon Brunette
 layout: single
 guid: https://opendatakit.org/?p=7743
-permalink: /2016/07/05/bolivian-red-cross-and-international-federation-of-red-cross-and-red-crescent-societies-use-odk-to-combat-zika/
 categories:
   - Uncategorized
 ---

--- a/_posts/2016-08-17-the-future-of-open-data-kit.md
+++ b/_posts/2016-08-17-the-future-of-open-data-kit.md
@@ -5,7 +5,6 @@ date: 2016-08-17T16:27:13+00:00
 author: Richard Anderson
 layout: single
 guid: https://opendatakit.org/?p=7798
-permalink: /2016/08/17/the-future-of-open-data-kit/
 categories:
   - Uncategorized
 ---

--- a/_posts/2016-10-27-odk-collect-v1-4-11-available-for-download.md
+++ b/_posts/2016-10-27-odk-collect-v1-4-11-available-for-download.md
@@ -5,7 +5,6 @@ date: 2016-10-27T06:27:45+00:00
 author: Yaw Anokwa
 layout: single
 guid: https://opendatakit.org/?p=8089
-permalink: /2016/10/27/odk-collect-v1-4-11-available-for-download/
 categories:
   - Uncategorized
 ---

--- a/_posts/2016-11-29-odk-collect-v1-4-12-has-been-released.md
+++ b/_posts/2016-11-29-odk-collect-v1-4-12-has-been-released.md
@@ -5,7 +5,6 @@ date: 2016-11-29T09:54:22+00:00
 author: Yaw Anokwa
 layout: single
 guid: https://opendatakit.org/?p=8129
-permalink: /2016/11/29/odk-collect-v1-4-12-has-been-released/
 categories:
   - Uncategorized
 ---

--- a/_posts/2017-01-24-updates-to-odk-collect-odk-build-and-odk-briefcase-now-available.md
+++ b/_posts/2017-01-24-updates-to-odk-collect-odk-build-and-odk-briefcase-now-available.md
@@ -5,7 +5,6 @@ date: 2017-01-24T00:52:45+00:00
 author: Yaw Anokwa
 layout: single
 guid: https://opendatakit.org/?p=8173
-permalink: /2017/01/24/updates-to-odk-collect-odk-build-and-odk-briefcase-now-available/
 categories:
   - Uncategorized
 ---

--- a/_posts/2017-02-24-odk-collect-v1-4-16-available-for-download.md
+++ b/_posts/2017-02-24-odk-collect-v1-4-16-available-for-download.md
@@ -5,7 +5,6 @@ date: 2017-02-24T08:57:57+00:00
 author: Yaw Anokwa
 layout: single
 guid: https://opendatakit.org/?p=8259
-permalink: /2017/02/24/odk-collect-v1-4-16-available-for-download/
 categories:
   - Uncategorized
 ---

--- a/_posts/2017-03-24-update-on-open-data-kit-transition.md
+++ b/_posts/2017-03-24-update-on-open-data-kit-transition.md
@@ -5,7 +5,6 @@ date: 2017-03-24T14:15:55+00:00
 author: Richard Anderson
 layout: single
 guid: https://opendatakit.org/?p=8289
-permalink: /2017/03/24/update-on-open-data-kit-transition/
 categories:
   - Uncategorized
 ---

--- a/_posts/2017-03-28-odk-collect-v1-5-1-released.md
+++ b/_posts/2017-03-28-odk-collect-v1-5-1-released.md
@@ -5,7 +5,6 @@ date: 2017-03-28T18:18:05+00:00
 author: Yaw Anokwa
 layout: single
 guid: https://opendatakit.org/?p=8293
-permalink: /2017/03/28/odk-collect-v1-5-1-released/
 categories:
   - Uncategorized
 ---

--- a/_posts/2017-04-12-odk-management-transition-survey.md
+++ b/_posts/2017-04-12-odk-management-transition-survey.md
@@ -5,7 +5,6 @@ date: 2017-04-12T15:01:52+00:00
 author: Waylon Brunette
 layout: single
 guid: https://opendatakit.org/?p=8316
-permalink: /2017/04/12/odk-management-transition-survey/
 categories:
   - Uncategorized
 ---

--- a/_posts/2017-05-03-odk-collect-v1-6-1-odk-build-v0-3-0-and-odk-briefcase-v1-5-0-are-now-available.md
+++ b/_posts/2017-05-03-odk-collect-v1-6-1-odk-build-v0-3-0-and-odk-briefcase-v1-5-0-are-now-available.md
@@ -5,7 +5,6 @@ date: 2017-05-03T14:14:58+00:00
 author: Yaw Anokwa
 layout: single
 guid: https://opendatakit.org/?p=8331
-permalink: /2017/05/03/odk-collect-v1-6-1-odk-build-v0-3-0-and-odk-briefcase-v1-5-0-are-now-available/
 categories:
   - Uncategorized
 ---

--- a/_posts/2017-05-17-connect-qgis-layers-and-odk-forms-with-qgisodk.md
+++ b/_posts/2017-05-17-connect-qgis-layers-and-odk-forms-with-qgisodk.md
@@ -5,7 +5,6 @@ date: 2017-05-17T09:53:01+00:00
 author: Hélène Martin
 layout: single
 guid: https://opendatakit.org/?p=8356
-permalink: /2017/05/17/connect-qgis-layers-and-odk-forms-with-qgisodk/
 categories:
   - Uncategorized
 ---

--- a/_posts/2017-06-01-collect-1-7-0-javarosa-2-2-0-and-validate-1-5-0-released.md
+++ b/_posts/2017-06-01-collect-1-7-0-javarosa-2-2-0-and-validate-1-5-0-released.md
@@ -5,7 +5,6 @@ date: 2017-06-01T15:40:01+00:00
 author: Yaw Anokwa
 layout: single
 guid: https://opendatakit.org/?p=8414
-permalink: /2017/06/01/collect-1-7-0-javarosa-2-2-0-and-validate-1-5-0-released/
 categories:
   - Uncategorized
 ---

--- a/_posts/2017-06-01-configure-collect-on-many-devices-with-qr-codes.md
+++ b/_posts/2017-06-01-configure-collect-on-many-devices-with-qr-codes.md
@@ -5,7 +5,6 @@ date: 2017-06-01T15:11:15+00:00
 author: Hélène Martin
 layout: single
 guid: https://opendatakit.org/?p=8402
-permalink: /2017/06/01/configure-collect-on-many-devices-with-qr-codes/
 categories:
   - Uncategorized
 ---

--- a/_posts/2017-06-01-important-moving-from-google-groups-to-discourse-on-friday.md
+++ b/_posts/2017-06-01-important-moving-from-google-groups-to-discourse-on-friday.md
@@ -5,7 +5,6 @@ date: 2017-06-01T15:40:32+00:00
 author: Yaw Anokwa
 layout: single
 guid: https://opendatakit.org/?p=8368
-permalink: /2017/06/01/important-moving-from-google-groups-to-discourse-on-friday/
 categories:
   - Uncategorized
 ---

--- a/_posts/2017-06-04-how-to-get-started-on-the-odk-forum.md
+++ b/_posts/2017-06-04-how-to-get-started-on-the-odk-forum.md
@@ -5,7 +5,7 @@ date: 2017-06-04T15:07:09+00:00
 author: Yaw Anokwa
 layout: single
 guid: https://opendatakit.org/?p=8418
-permalink: /2017/06/04/how-to-get-started-on-the-odk-forum/
+
 categories:
   - Uncategorized
 ---


### PR DESCRIPTION
Closes #125 

#### What is included in this PR?

 - add a day-less permalink structure to _config.yml
 - remove the in-file permalink attr. from the front matter of all the posts

#### Tested

I spot checked:

 - from local/blog --- posts seemed to be in the right place
 - from existing site --- I opened a bunch of posts from the old blog and then subbed-in the localhost domain, leaving the rest of the URL string. Everything seemed to work.
 - clicked around the rest of the site to make sure other URLs were not affected

#### What problems did you encounter?

##### _config.yml has two blog/post related sections

There are two `defaults` subsections that seem to refer to blog posts. The one that seemed more likely (`path: _posts`) was actually the wrong one to accomplish this. So I tried the other one and --- though I'm not sure why --- it worked.

Someone should look at the config file and clean this up. I suspect there's a lot of redundancy and cargo-culting left over from the theme/examples.

##### grep does something weird with end lines

If you look at the diff, every post file says the last line was changed, but the diff doesn't show how exactly. This is likely something to do with how the file was copied and re-saved, but I don't know what. Seems harmless.