### PR TITLE
Redirect high traffic pages

### DIFF
--- a/s3_website.yml
+++ b/s3_website.yml
@@ -25,4 +25,9 @@ cloudfront_distribution_config:
 cloudfront_wildcard_invalidation: true
 
 redirects:
-  xiframe: software/odk1/xiframe
+  downloads: software
+  use/aggregate: https://docs.opendatakit.org/aggregate-intro
+  use/build: https://docs.opendatakit.org/build-intro
+  use/xlsform: https://docs.opendatakit.org/xlsform
+  use: https://docs.opendatakit.org
+  xiframe: https://xlsform.opendatakit.org


### PR DESCRIPTION
Addresses #38

#### What is included in this PR?
Looked at high-traffic links in Google Analytics and made sure those redirects work
<img width="514" alt="screen shot 2018-05-29 at 11 58 53" src="https://user-images.githubusercontent.com/32369/40681450-fa29b500-633d-11e8-9ed3-537217c0e55a.png">

#### What is left to be done in the addressed issue?
* Confirm that incoming download links (e.g., https://opendatakit.org/downloads/download-category/briefcase) at least end up on the /software page.
* Everything listed at #38
