### PR TITLE
Adds more redirects

### DIFF
--- a/s3_website.yml
+++ b/s3_website.yml
@@ -25,11 +25,83 @@ cloudfront_distribution_config:
 cloudfront_wildcard_invalidation: true
 
 routing_rules:
+  # help/form-design/*
+  - condition:
+      key_prefix_equals: help/form-design/external-apps
+    redirect:
+      host_name: docs.opendatakit.org
+      replace_key_with: launch-apps-from-collect
+      http_redirect_code: 301
+  - condition:
+      key_prefix_equals: help/form-design/itext
+    redirect:
+      host_name: docs.opendatakit.org
+      replace_key_with: form-language
+      http_redirect_code: 301 
+  - condition:
+      key_prefix_equals: help/form-design/workarounds
+    redirect:
+      host_name: docs.opendatakit.org
+      replace_key_with: form-best-practices
+      http_redirect_code: 301       
   - condition:
       key_prefix_equals: help/form-design
     redirect:
       host_name: docs.opendatakit.org
       replace_key_with: form-design-intro
+      http_redirect_code: 301
+  # help/*
+  - condition:
+      key_prefix_equals: help/image-based-forms
+    redirect:
+      host_name: docs.opendatakit.org
+      replace_key_with: form-question-types/#including-images-as-choices
+      http_redirect_code: 301
+  - condition:
+      key_prefix_equals: help/verifying-downloaded-files
+    redirect:
+      host_name: docs.opendatakit.org
+      replace_key_with: verify-downloads
+      http_redirect_code: 301
+  - condition:
+      key_prefix_equals: help/encrypted-forms
+    redirect:
+      host_name: docs.opendatakit.org
+      replace_key_with: encrypted-forms
+      http_redirect_code: 301
+  # help
+  - condition:
+      key_prefix_equals: help
+    redirect:
+      host_name: staging.opendatakit.org
+      replace_key_with: help
+      http_redirect_code: 301
+
+      
+  # use/aggregate/*
+  - condition:
+      key_prefix_equals: use/aggregate/data-transfer
+    redirect:
+      host_name: docs.opendatakit.org
+      replace_key_with: aggregate-data-access
+      http_redirect_code: 301  
+  - condition:
+      key_prefix_equals: use/aggregate/deployment-planning
+    redirect:
+      host_name: docs.opendatakit.org
+      replace_key_with: aggregate-deployment-planning
+      http_redirect_code: 301
+  - condition:
+      key_prefix_equals: use/aggregate/oauth2-service-account
+    redirect:
+      host_name: docs.opendatakit.org
+      replace_key_with: oauth2-service
+      http_redirect_code: 301
+  - condition:
+      key_prefix_equals: use/aggregate/tomcat-install
+    redirect:
+      host_name: docs.opendatakit.org
+      replace_key_with: aggregate-tomcat
       http_redirect_code: 301
   - condition:
       key_prefix_equals: use/aggregate
@@ -37,29 +109,89 @@ routing_rules:
       host_name: docs.opendatakit.org
       replace_key_with: aggregate-intro
       http_redirect_code: 301
+      
+  # use/briefcase
   - condition:
       key_prefix_equals: use/briefcase
     redirect:
       host_name: docs.opendatakit.org
       replace_key_with: briefcase-intro
       http_redirect_code: 301
+  # use/build
   - condition:
       key_prefix_equals: use/build
     redirect:
       host_name: docs.opendatakit.org
       replace_key_with: build-intro
       http_redirect_code: 301
+  # use/collect
   - condition:
       key_prefix_equals: use/collect
     redirect:
       host_name: docs.opendatakit.org
       replace_key_with: collect-intro
       http_redirect_code: 301
+  # use/form-uploader
+  - condition:
+      key_prefix_equals: use/form-uploader
+    redirect:
+      host_name: docs.opendatakit.org
+      replace_key_with: form-uploader
+      http_redirect_code: 301
+  # use/sensors/zebra-printer-driver
+  - condition:
+      key_prefix_equals: use/sensors/zebra-printer-driver
+    redirect:
+      host_name: docs.opendatakit.org
+      replace_key_with: printer-widget
+      http_redirect_code: 301  
+  # use/validate
+  - condition:
+      key_prefix_equals: use/validate
+    redirect:
+      host_name: docs.opendatakit.org
+      replace_key_with: validate
+      http_redirect_code: 301
+  # use/xls    
   - condition:
       key_prefix_equals: use/xls
     redirect:
       host_name: docs.opendatakit.org
       replace_key_with: xlsform
+      http_redirect_code: 301
+  # use/2_0_tools
+   - condition:
+      key_prefix_equals: use/2_0_tools
+    redirect:
+      host_name: docs.opendatakit.org/odk2
+      replace_key_with: ""
+      http_redirect_code: 301
+  # use
+  - condition:
+      key_prefix_equals: use
+    redirect:
+      host_name: docs.opendatakit.org
+      replace_key_with: ""
+      http_redirect_code: 301
+      
+  # about/*
+  - condition:
+      key_prefix_equals: about/deployments
+    redirect:
+      host_name: forum.opendatakit.org
+      replace_key_with: c/showcase
+      http_redirect_code: 301
+  - condition:
+      key_prefix_equals:   about/security-and-privacy-statement
+    redirect:
+      host_name: docs.opendatakit.org
+      replace_key_with: security-privacy
+      http_redirect_code: 301
+  - condition:
+      key_prefix_equals: about/tools
+    redirect:
+      host_name: staging.opendatakit.org
+      replace_key_with: software
       http_redirect_code: 301
   - condition:
       key_prefix_equals: about
@@ -67,24 +199,24 @@ routing_rules:
       host_name: staging.opendatakit.org
       replace_key_with: ""
       http_redirect_code: 301
+      
+  # downloads
   - condition:
       key_prefix_equals: downloads
     redirect:
       host_name: staging.opendatakit.org
       replace_key_with: software
       http_redirect_code: 301
+
+  # participate
   - condition:
       key_prefix_equals: participate
     redirect:
       host_name: staging.opendatakit.org
       replace_key_with: community
       http_redirect_code: 301
-  - condition:
-      key_prefix_equals: use
-    redirect:
-      host_name: docs.opendatakit.org
-      replace_key_with: ""
-      http_redirect_code: 301
+      
+  # xiframe
   - condition:
       key_prefix_equals: xiframe
     redirect:


### PR DESCRIPTION
#### What is included in this PR?

Redirects for nearly every old site page.

As far as I can tell, this covers:

 - every ODK1 "docs" page that we intended to migrate.
 - every ODK general page that has a reasonable parallel on the new site.

ODK2 pages are redirected *en masse* from `2_0_tools` to ODK2 Docs.

#### What is left to be done in the addressed issue?

Someone *might* want to go through the catalog of ODK2 pages and specify particular pages in the ODK2 docs. 


--------

There's no way to test this locally,
so please do a sanity check, a spot check, and any other kind of check you can think of.