### PR TITLE
Fix RSS feed and direct download links

### DIFF
--- a/s3_website.yml
+++ b/s3_website.yml
@@ -228,7 +228,7 @@ routing_rules:
       http_redirect_code: 301
   # downloads
   - condition:
-      key_prefix_equals: downloads
+      key_prefix_equals: download
     redirect:
       host_name: opendatakit.org
       replace_key_with: software
@@ -246,4 +246,11 @@ routing_rules:
     redirect:
       host_name: opendatakit.org
       replace_key_with: xlsform
+      http_redirect_code: 301
+  # feed
+  - condition:
+      key_prefix_equals: feed
+    redirect:
+      host_name: opendatakit.org
+      replace_key_with: feed.xml
       http_redirect_code: 301


### PR DESCRIPTION
#### What is included in this PR?
I checked the 404s we are seeing in Cloudfront and this fixes the big ones.
* /download/ is the direct link to some of the specific tools
* feed.xml is the RSS feed. I'm not sure this redirect will break peoples existing feeds, but I'm hoping not?