### PR TITLE
Remove follow language to prevent wrap on screens

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,8 +1,5 @@
 <div class="page__footer-follow">
   <ul class="social-icons">
-    {% if site.data.ui-text[site.locale].follow_label %}
-      <li><strong>{{ site.data.ui-text[site.locale].follow_label }}</strong></li>
-    {% endif %}
     {% if site.twitter.username %}
       <li><a href="https://twitter.com/{{ site.twitter.username }}"><i class="fab fa-fw fa-twitter-square" aria-hidden="true" style="margin-right: 4px"></i>Twitter</a></li>
     {% endif %}


### PR DESCRIPTION
#### What is included in this PR?
* This removes the "Follow:" Before the social icons. I think it's pretty obvious what those icons are and removing the follow means the feed link is on the same line as the rest.