### PR TITLE
Set photo attribution typeface as sans-serif. Close #67

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -43,5 +43,9 @@ $link-color-hover: #1590d3;
 }
 
 table {
-  table-layout: fixed;  
+  table-layout: fixed;
+}
+
+span.page__hero-caption {
+  font-family: sans-serif;
 }


### PR DESCRIPTION
Closes #67 

#### What is included in this PR?
Adds a line of CSS to the ./assets/css/main.scss file. 

#### What is left to be done in the addressed issue?
Decide whether we want the image attribution to follow the theme default (a serif typeface), or the same sans-serif as the rest of the site. 

This style modification is superficial. I'm indifferent to whether it is accepted or not, but this is the solution to the open issue.

Pro: typeface consistency. 
Con: ODK/website diverges from the theme.  
