### PR TITLE
Add styling to img tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 _site/
 .sass-cache/
 .jekyll-cache/

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -62,3 +62,10 @@ table {
 span.page__hero-caption {
   font-family: sans-serif;
 }
+
+img {
+  color: gray;
+  font-size: 20px;
+  font-style: italic;
+  font-weight: bolder;
+}


### PR DESCRIPTION
Closes #98 

#### What is included in this PR?

<!-- Answer any that apply and delete the others. -->
#### What new issues will need to be opened because of this PR?
None

#### What is left to be done in the addressed issue?
Needs review

#### What problems did you encounter?
I tried to use the `minimal-mistakes` theme's `figcation` as suggested [here](https://github.com/opendatakit/website/issues/98#issuecomment-432437412). But that adds a caption instead of just modifying the `alt` text's styling across all pages. Thus, wasn't the best solution to the problem

The image link shown in the below screenshots is intentionally broken to preview the change.

 
Before (firefox): 
![image](https://user-images.githubusercontent.com/8918023/51492777-fc077780-1dd8-11e9-8ad2-573555bdfdfa.png)

After (firefox):
![image](https://user-images.githubusercontent.com/8918023/51492705-c2cf0780-1dd8-11e9-8ba5-990d5bc55bcf.png)
