### PR TITLE
Use default layout to match rest of site

### DIFF
--- a/_pages/help/index.md
+++ b/_pages/help/index.md
@@ -1,10 +1,7 @@
 ---
 title: Help
-layout: splash
 permalink: /help/
 ---
-
-# Help
 
 Our community produces two suites of software: ODK and ODK-X (formerly ODK 2).
 

--- a/_pages/software/index.md
+++ b/_pages/software/index.md
@@ -1,10 +1,7 @@
 ---
 title: Software
-layout: splash
 permalink: /software/
 ---
-
-# Software
 
 Our community produces two suites of software: ODK and ODK-X (formerly ODK 2).
 


### PR DESCRIPTION
Makes the page a lot easier to read. This reverts an unintended change from #231. I remove first line of the text because the title is put there in this theme.

<img width="1294" alt="Screen Shot 2019-06-04 at 4 38 57 PM" src="https://user-images.githubusercontent.com/32369/58920483-4550c780-86e7-11e9-9bcb-079c473d14da.png">
