### PR TITLE
s3_website requires Java 8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,11 @@ jobs:
           name: Install deploy requirements
           command: |
               if [[ "$CIRCLE_PROJECT_USERNAME" == "opendatakit" ]]; then \
-                sudo apt-get install -y pngquant openjdk-11-jre-headless
+                sudo apt-get install -y software-properties-common
+                wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | sudo apt-key add -
+                sudo add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
+                sudo apt-get update
+                sudo apt-get install -y pngquant adoptopenjdk-8-hotspot
                 gem install s3_website && s3_website install
               fi
       - run:


### PR DESCRIPTION
Addresses #242

s3_website requires Java 8. We could install jenv or something like this, but that is pretty heavy for a build server. adoptopenjdk seems to be the popular JDK and so I've added the instructions from https://adoptopenjdk.net/installation.html.

I've confirmed this stuff works by running through all the commands (instead of just the install command).